### PR TITLE
Track contacts by name instead of phone number

### DIFF
--- a/lib/core/manager.dart
+++ b/lib/core/manager.dart
@@ -20,7 +20,6 @@ import 'package:logger/screens/settings/fragments/export_info/json_fields.dart';
 import 'package:logger/screens/tracklist/fragments/add_new_number_to_track_list_dialog.dart';
 import 'package:logger/utils/file_types.dart';
 import 'package:logger/utils/generate_files.dart';
-import 'package:logger/utils/phone_formatter.dart';
 import 'package:logger/utils/snackbar.dart';
 import 'package:logger/utils/exported_filename_formatter.dart';
 import 'package:share_plus/share_plus.dart';
@@ -396,21 +395,19 @@ class _ScreenManagerState extends ConsumerState<ScreenManager> {
 
   void registerNewTrackListItem(currentContext) async {
     try {
-      String? newNumber = await showAdaptiveDialog<String>(
+      String? newContactName = await showAdaptiveDialog<String>(
         context: currentContext,
         builder: (context) {
-          return AddNewNumberToTrackListDialog(
-            currentNumbers: ref.read(trackListProvider).value ?? [],
+          return AddNewContactToTrackListDialog(
+            currentContacts: ref.read(trackListProvider).value ?? [],
           );
         },
       );
 
-      if (newNumber != null) {
-        newNumber = PhoneFormatter.parsePhoneNumber(newNumber);
-
+      if (newContactName != null) {
         ref
             .read(trackListProvider.notifier)
-            .registerNumberIfNotPresent(newNumber);
+            .registerContactIfNotPresent(newContactName);
       }
     } catch (E) {
       if (mounted) {

--- a/lib/data/datasource/datasource.dart
+++ b/lib/data/datasource/datasource.dart
@@ -21,7 +21,7 @@ class Datasource {
   Future<Database> _initDb() async {
     return await openDatabase(
       dbName,
-      version: 2,
+      version: 3,
       onCreate: _onCreate,
       onUpgrade: _onUpgrade,
     );
@@ -49,7 +49,7 @@ class Datasource {
     await db.execute('''
     CREATE TABLE IF NOT EXISTS ${TrackListDatasource.tableName} (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
-      phone_number TEXT UNIQUE,
+      contact_name TEXT UNIQUE,
       creation_timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
     )
   ''');
@@ -61,6 +61,16 @@ class Datasource {
       CREATE TABLE tracklist (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         phone_number TEXT UNIQUE,
+        creation_timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+      )
+    ''');
+    }
+    if (oldVersion < 3) {
+      await db.execute('DROP TABLE IF EXISTS ${TrackListDatasource.tableName}');
+      await db.execute('''
+      CREATE TABLE ${TrackListDatasource.tableName} (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        contact_name TEXT UNIQUE,
         creation_timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
       )
     ''');

--- a/lib/data/datasource/tracklist_datasource.dart
+++ b/lib/data/datasource/tracklist_datasource.dart
@@ -11,41 +11,41 @@ class TrackListDatasource {
 
   TrackListDatasource._();
 
-  Future<int> registerNumber(String phoneNumber) async {
+  Future<int> registerContact(String contactName) async {
     final db = await _ds.database;
 
     return db.transaction((txn) async {
       return await txn.insert(
         tableName,
-        TrackListItem.fromNumber(phoneNumber).toJSON(),
+        TrackListItem.fromName(contactName).toJSON(),
         conflictAlgorithm: ConflictAlgorithm.replace,
       );
     });
   }
 
-  Future<int> registerNumberIfNotPresent(String phoneNumber) async {
+  Future<int> registerContactIfNotPresent(String contactName) async {
     final db = await _ds.database;
 
     return db.transaction((txn) async {
       final List<Map<String, dynamic>> maps = await txn.query(
         tableName,
-        where: "phone_number = ?",
-        whereArgs: [phoneNumber],
+        where: "contact_name = ?",
+        whereArgs: [contactName],
       );
 
       if (maps.isNotEmpty) {
-        throw Exception("Phone number already registered");
+        throw Exception("Contact already registered");
       }
 
       return await txn.insert(
         tableName,
-        TrackListItem.fromNumber(phoneNumber).toJSON(),
+        TrackListItem.fromName(contactName).toJSON(),
         conflictAlgorithm: ConflictAlgorithm.replace,
       );
     });
   }
 
-  Future<List<TrackListItem>> getNumbers() async {
+  Future<List<TrackListItem>> getContacts() async {
     final db = await _ds.database;
     final List<Map<String, dynamic>> maps = await db.query(
       tableName,
@@ -59,7 +59,7 @@ class TrackListDatasource {
     );
   }
 
-  Future<int> removeNumberById(int id) async {
+  Future<int> removeContactById(int id) async {
     final db = await _ds.database;
     return db.transaction(
       (txn) async {

--- a/lib/data/models/tracklist_item.dart
+++ b/lib/data/models/tracklist_item.dart
@@ -1,44 +1,44 @@
 class TrackListItem {
   final int id;
-  final String phoneNumber;
+  final String contactName;
 
   const TrackListItem({
     this.id = -1,
-    required this.phoneNumber,
+    required this.contactName,
   });
 
   static final TrackListItem defaultItem = TrackListItem(
     id: -1,
-    phoneNumber: "",
+    contactName: "",
   );
 
   Map<String, dynamic> toJSON() {
     return {
       "id": id == -1 ? null : id,
-      "phone_number": phoneNumber,
+      "contact_name": contactName,
     };
   }
 
   factory TrackListItem.fromJson(Map<String, dynamic> map) {
     return TrackListItem(
       id: map["id"] as int,
-      phoneNumber: map["phone_number"] as String,
+      contactName: map["contact_name"] as String,
     );
   }
 
-  factory TrackListItem.fromNumber(String phoneNumber) {
+  factory TrackListItem.fromName(String contactName) {
     return TrackListItem(
-      phoneNumber: phoneNumber,
+      contactName: contactName,
     );
   }
 
   TrackListItem copyWith({
     int? id,
-    String? phoneNumber,
+    String? contactName,
   }) {
     return TrackListItem(
       id: id ?? this.id,
-      phoneNumber: phoneNumber ?? this.phoneNumber,
+      contactName: contactName ?? this.contactName,
     );
   }
 }

--- a/lib/data/repostiory/tracklist_repository.dart
+++ b/lib/data/repostiory/tracklist_repository.dart
@@ -5,33 +5,33 @@ class TrackListRepository {
   final TrackListDatasource _datasource;
   TrackListRepository(this._datasource);
 
-  Future<void> registerNumber(String phoneNumber) async {
+  Future<void> registerContact(String contactName) async {
     try {
-      await _datasource.registerNumber(phoneNumber);
+      await _datasource.registerContact(contactName);
     } catch (e) {
       throw '$e';
     }
   }
 
-  Future<void> registerNumberIfNotPresent(String phoneNumber) async {
+  Future<void> registerContactIfNotPresent(String contactName) async {
     try {
-      await _datasource.registerNumberIfNotPresent(phoneNumber);
+      await _datasource.registerContactIfNotPresent(contactName);
     } catch (e) {
       throw '$e';
     }
   }
 
-  Future<void> removeNumberById(int id) async {
+  Future<void> removeContactById(int id) async {
     try {
-      await _datasource.removeNumberById(id);
+      await _datasource.removeContactById(id);
     } catch (e) {
       throw '$e';
     }
   }
 
-  Future<List<TrackListItem>> getNumbers() async {
+  Future<List<TrackListItem>> getContacts() async {
     try {
-      return await _datasource.getNumbers();
+      return await _datasource.getContacts();
     } catch (e) {
       throw '$e';
     }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -240,9 +240,9 @@
     "disableLogsSharingText": "Teilen-Button ausblenden",
     "disableLogsSharingSubText": "Den Teilen-Button in den Anrufprotokollen verbergen",
     "trackListLabelText": "Trackliste",
-    "tracklistPlaceholderText": "Verwalten Sie Ihre Trackliste effizient. Tippen Sie auf + (oben rechts), um eine Nummer hinzuzufügen, wischen Sie nach links auf einem Listeneintrag und tippen Sie auf Entfernen, um die Verfolgung zu stoppen.",
+    "tracklistPlaceholderText": "Verwalten Sie Ihre verfolgten Kontakte effizient. Tippen Sie auf + (oben rechts), um einen Kontakt hinzuzufügen, wischen Sie nach links auf einem Listeneintrag und tippen Sie auf Entfernen, um die Verfolgung zu stoppen.",
     "removeAllText": "alle entfernen",
-    "trackContactLabelText": "Telefonnummer",
+    "trackContactLabelText": "Kontaktname",
     "trackContactText": "Kontakt verfolgen",
     "removeText": "Entfernen",
     "iteractionScoreText": "Interaktionspunktzahl",
@@ -254,9 +254,9 @@
     "callDistByWeekDay": "Anrufverteilung nach Wochentagen (%)",
     "addToTrackList": "Fügen Sie bis zu {maxItems} Kontakte zu Ihrer Trackliste für einfaches Tracking hinzu.",
     "addText": "Hinzufügen",
-    "numberAlreadyAddedErrorText": "Nummer bereits hinzugefügt",
+    "numberAlreadyAddedErrorText": "Kontakt bereits hinzugefügt",
     "invalidNumberErrorText": "Ungültige Telefonnummer",
-    "emptyPhoneNumberErrorText": "Geben Sie eine Telefonnummer ein",
+    "emptyPhoneNumberErrorText": "Geben Sie einen Kontaktnamen ein",
     "trackNumberErrorText": "Beim Hinzufügen des neuen Track-Kontakts ist ein Fehler aufgetreten",
     "quickFilterText": "Schnellfilter"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -817,9 +817,9 @@
   "disableLogsSharingText": "Hide share button",
   "disableLogsSharingSubText": "Conceal the share button in the call logs",
   "trackListLabelText": "Tracklist",
-  "tracklistPlaceholderText": "Manage your track list efficiently. Tap + (top-right) to add a number, swipe left on a list item and tap Remove to untrack.",
+  "tracklistPlaceholderText": "Manage your tracked contacts efficiently. Tap + (top-right) to add a contact, swipe left on a list item and tap Remove to untrack.",
   "removeAllText": "remove all",
-  "trackContactLabelText": "Phone Number",
+  "trackContactLabelText": "Contact Name",
   "trackContactText": "Track a Contact",
   "removeText": "Remove",
   "iteractionScoreText": "Interaction Score",
@@ -831,9 +831,9 @@
   "callDistByWeekDay": "Call Distribution by Weekday (%)",
   "addToTrackList": "Add up to {maxItems} contacts to your tracklist for easy tracking.",
   "addText": "Add",
-  "numberAlreadyAddedErrorText": "Number already added",
+  "numberAlreadyAddedErrorText": "Contact already added",
   "invalidNumberErrorText": "Invalid phone number",
-  "emptyPhoneNumberErrorText": "Enter a phone number",
+  "emptyPhoneNumberErrorText": "Enter a contact name",
   "trackNumberErrorText": "Something went wrong adding new track contact",
   "quickFilterText": "Quick Filter"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -240,9 +240,9 @@
   "disableLogsSharingText": "Ocultar botón de compartir",
   "disableLogsSharingSubText": "Ocultar el botón de compartir en el historial de llamadas",
   "trackListLabelText": "Lista de seguimiento",
-  "tracklistPlaceholderText": "Administra tu lista de seguimiento de manera eficiente. Toca + (arriba a la derecha) para agregar un número, desliza a la izquierda sobre un elemento de la lista y toca Eliminar para dejar de seguir.",
+  "tracklistPlaceholderText": "Administra tus contactos rastreados de manera eficiente. Toca + (arriba a la derecha) para agregar un contacto, desliza a la izquierda sobre un elemento de la lista y toca Eliminar para dejar de seguir.",
   "removeAllText": "eliminar todo",
-  "trackContactLabelText": "Número de teléfono",
+  "trackContactLabelText": "Nombre del contacto",
   "trackContactText": "Rastrear un contacto",
   "removeText": "Eliminar",
   "iteractionScoreText": "Puntaje de interacción",
@@ -254,9 +254,9 @@
   "callDistByWeekDay": "Distribución de llamadas por día de la semana (%)",
   "addToTrackList": "Agrega hasta {maxItems} contactos a tu lista de seguimiento para un seguimiento fácil.",
   "addText": "Agregar",
-  "numberAlreadyAddedErrorText": "Número ya agregado",
+  "numberAlreadyAddedErrorText": "Contacto ya agregado",
   "invalidNumberErrorText": "Número de teléfono inválido",
-  "emptyPhoneNumberErrorText": "Ingrese un número de teléfono",
+  "emptyPhoneNumberErrorText": "Ingrese un nombre de contacto",
   "trackNumberErrorText": "Ocurrió un error al agregar el nuevo contacto de seguimiento",
   "quickFilterText": "Filtro rápido"
 }

--- a/lib/l10n/app_fi.arb
+++ b/lib/l10n/app_fi.arb
@@ -240,9 +240,9 @@
     "disableLogsSharingText": "Piilota jakopainike",
     "disableLogsSharingSubText": "Piilota jakopainike puhelulokeissa",
     "trackListLabelText": "Seurantalista",
-    "tracklistPlaceholderText": "Hallitse seurantalistaasi tehokkaasti. Napauta + (oikeassa yläkulmassa) lisätäksesi numeron, pyyhkäise vasemmalle listan kohteessa ja napauta Poista poistaaksesi seurannan.",
+    "tracklistPlaceholderText": "Hallitse seurattavia kontaktejasi tehokkaasti. Napauta + (oikeassa yläkulmassa) lisätäksesi kontaktin, pyyhkäise vasemmalle listan kohteessa ja napauta Poista poistaaksesi seurannan.",
     "removeAllText": "poista kaikki",
-    "trackContactLabelText": "Puhelinnumero",
+    "trackContactLabelText": "Kontaktin nimi",
     "trackContactText": "Seuraa kontaktia",
     "removeText": "Poista",
     "iteractionScoreText": "Vuorovaikutuspisteet",
@@ -254,9 +254,9 @@
     "callDistByWeekDay": "Puhelujen jakautuminen viikonpäivittäin (%)",
     "addToTrackList": "Lisää jopa {maxItems} kontaktia seurantalistaasi helppoa seurantaa varten.",
     "addText": "Lisää",
-    "numberAlreadyAddedErrorText": "Numero on jo lisätty",
+    "numberAlreadyAddedErrorText": "Kontakti on jo lisätty",
     "invalidNumberErrorText": "Virheellinen puhelinnumero",
-    "emptyPhoneNumberErrorText": "Anna puhelinnumero",
+    "emptyPhoneNumberErrorText": "Anna kontaktin nimi",
     "trackNumberErrorText": "Uuden seurattavan kontaktin lisäämisessä tapahtui virhe",
     "quickFilterText": "Pikasuodatin"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -240,9 +240,9 @@
     "disableLogsSharingText": "Masquer le bouton de partage",
     "disableLogsSharingSubText": "Masquer le bouton de partage dans les journaux d'appels",
     "trackListLabelText": "Liste de suivi",
-    "tracklistPlaceholderText": "Gérez votre liste de suivi efficacement. Appuyez sur + (en haut à droite) pour ajouter un numéro, faites glisser un élément de la liste vers la gauche et appuyez sur Supprimer pour ne plus suivre.",
+    "tracklistPlaceholderText": "Gérez vos contacts suivis efficacement. Appuyez sur + (en haut à droite) pour ajouter un contact, faites glisser un élément de la liste vers la gauche et appuyez sur Supprimer pour ne plus suivre.",
     "removeAllText": "tout supprimer",
-    "trackContactLabelText": "Numéro de téléphone",
+    "trackContactLabelText": "Nom du contact",
     "trackContactText": "Suivre un contact",
     "removeText": "Supprimer",
     "iteractionScoreText": "Score d'interaction",
@@ -254,9 +254,9 @@
     "callDistByWeekDay": "Répartition des appels par jour de la semaine (%)",
     "addToTrackList": "Ajoutez jusqu'à {maxItems} contacts à votre liste de suivi pour un suivi facile.",
     "addText": "Ajouter",
-    "numberAlreadyAddedErrorText": "Numéro déjà ajouté",
+    "numberAlreadyAddedErrorText": "Contact déjà ajouté",
     "invalidNumberErrorText": "Numéro de téléphone invalide",
-    "emptyPhoneNumberErrorText": "Entrez un numéro de téléphone",
+    "emptyPhoneNumberErrorText": "Entrez un nom de contact",
     "trackNumberErrorText": "Une erreur est survenue lors de l'ajout d'un nouveau contact à suivre",
     "quickFilterText": "Filtre rapide"
 }

--- a/lib/l10n/app_hi.arb
+++ b/lib/l10n/app_hi.arb
@@ -249,9 +249,9 @@
   "disableLogsSharingText": "शेयर बटन छुपाएँ",
   "disableLogsSharingSubText": "कॉल लॉग में शेयर बटन छुपाएँ",
   "trackListLabelText": "ट्रैक लिस्ट",
-  "tracklistPlaceholderText": "अपनी ट्रैक लिस्ट को कुशलतापूर्वक प्रबंधित करें। नंबर जोड़ने के लिए ऊपर-दाएँ + पर टैप करें, किसी लिस्ट आइटम पर बाईं ओर स्वाइप करें और अनट्रैक करने के लिए Remove पर टैप करें।",
+  "tracklistPlaceholderText": "अपने ट्रैक किए गए संपर्कों को कुशलतापूर्वक प्रबंधित करें। संपर्क जोड़ने के लिए ऊपर-दाएँ + पर टैप करें, किसी लिस्ट आइटम पर बाईं ओर स्वाइप करें और अनट्रैक करने के लिए Remove पर टैप करें।",
   "removeAllText": "सभी हटाएँ",
-  "trackContactLabelText": "फ़ोन नंबर",
+  "trackContactLabelText": "संपर्क का नाम",
   "trackContactText": "संपर्क ट्रैक करें",
   "removeText": "हटाएँ",
   "iteractionScoreText": "इंटरैक्शन स्कोर",
@@ -263,9 +263,9 @@
   "callDistByWeekDay": "सप्ताह के दिन अनुसार कॉल वितरण (%)",
   "addToTrackList": "आसान ट्रैकिंग के लिए अपनी ट्रैक लिस्ट में {maxItems} तक संपर्क जोड़ें।",
   "addText": "जोड़ें",
-  "numberAlreadyAddedErrorText": "नंबर पहले से जोड़ा गया है",
+  "numberAlreadyAddedErrorText": "संपर्क पहले से जोड़ा गया है",
   "invalidNumberErrorText": "अमान्य फ़ोन नंबर",
-  "emptyPhoneNumberErrorText": "फ़ोन नंबर दर्ज करें",
+  "emptyPhoneNumberErrorText": "संपर्क का नाम दर्ज करें",
   "trackNumberErrorText": "नया ट्रैक संपर्क जोड़ते समय कुछ गलत हुआ",
   "quickFilterText": "त्वरित फ़िल्टर"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -240,9 +240,9 @@
   "disableLogsSharingText": "共有ボタンを非表示",
   "disableLogsSharingSubText": "通話ログで共有ボタンを隠す",
   "trackListLabelText": "トラックリスト",
-  "tracklistPlaceholderText": "トラックリストを効率的に管理します。番号を追加するには右上の + をタップし、リスト項目を左にスワイプして「削除」をタップして追跡を解除します。",
+  "tracklistPlaceholderText": "追跡中の連絡先を効率的に管理します。連絡先を追加するには右上の + をタップし、リスト項目を左にスワイプして「削除」をタップして追跡を解除します。",
   "removeAllText": "すべて削除",
-  "trackContactLabelText": "電話番号",
+  "trackContactLabelText": "連絡先名",
   "trackContactText": "連絡先を追跡",
   "removeText": "削除",
   "iteractionScoreText": "インタラクションスコア",
@@ -254,9 +254,9 @@
   "callDistByWeekDay": "曜日別通話分布 (%)",
   "addToTrackList": "簡単に追跡できるように、トラックリストに最大 {maxItems} 件の連絡先を追加できます。",
   "addText": "追加",
-  "numberAlreadyAddedErrorText": "番号は既に追加されています",
+  "numberAlreadyAddedErrorText": "連絡先は既に追加されています",
   "invalidNumberErrorText": "無効な電話番号",
-  "emptyPhoneNumberErrorText": "電話番号を入力してください",
+  "emptyPhoneNumberErrorText": "連絡先名を入力してください",
   "trackNumberErrorText": "新しいトラック連絡先の追加中にエラーが発生しました",
   "quickFilterText": "クイックフィルター"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -240,9 +240,9 @@
   "disableLogsSharingText": "공유 버튼 숨기기",
   "disableLogsSharingSubText": "통화 기록에서 공유 버튼 숨기기",
   "trackListLabelText": "트랙리스트",
-  "tracklistPlaceholderText": "트랙리스트를 효율적으로 관리하세요. 번호를 추가하려면 오른쪽 상단의 +를 누르고, 리스트 항목을 왼쪽으로 스와이프한 후 제거를 눌러 추적을 해제하세요.",
+  "tracklistPlaceholderText": "추적 중인 연락처를 효율적으로 관리하세요. 연락처를 추가하려면 오른쪽 상단의 +를 누르고, 리스트 항목을 왼쪽으로 스와이프한 후 제거를 눌러 추적을 해제하세요.",
   "removeAllText": "모두 제거",
-  "trackContactLabelText": "전화번호",
+  "trackContactLabelText": "연락처 이름",
   "trackContactText": "연락처 추적",
   "removeText": "제거",
   "iteractionScoreText": "상호작용 점수",
@@ -254,9 +254,9 @@
   "callDistByWeekDay": "요일별 통화 분포 (%)",
   "addToTrackList": "간편한 추적을 위해 트랙리스트에 최대 {maxItems}명의 연락처를 추가하세요.",
   "addText": "추가",
-  "numberAlreadyAddedErrorText": "번호가 이미 추가됨",
+  "numberAlreadyAddedErrorText": "연락처가 이미 추가됨",
   "invalidNumberErrorText": "잘못된 전화번호",
-  "emptyPhoneNumberErrorText": "전화번호를 입력하세요",
+  "emptyPhoneNumberErrorText": "연락처 이름을 입력하세요",
   "trackNumberErrorText": "새 트랙 연락처를 추가하는 중 오류가 발생했습니다",
   "quickFilterText": "빠른 필터"
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -240,9 +240,9 @@
   "disableLogsSharingText": "Deelknop verbergen",
   "disableLogsSharingSubText": "Verberg de deelknop in de oproeplogs",
   "trackListLabelText": "Volglijst",
-  "tracklistPlaceholderText": "Beheer je volglijst efficiënt. Tik op + (rechtsboven) om een nummer toe te voegen, veeg een lijstitem naar links en tik op Verwijderen om het volgen te stoppen.",
+  "tracklistPlaceholderText": "Beheer je gevolgde contacten efficiënt. Tik op + (rechtsboven) om een contact toe te voegen, veeg een lijstitem naar links en tik op Verwijderen om het volgen te stoppen.",
   "removeAllText": "alles verwijderen",
-  "trackContactLabelText": "Telefoonnummer",
+  "trackContactLabelText": "Contactnaam",
   "trackContactText": "Volg een contact",
   "removeText": "Verwijderen",
   "iteractionScoreText": "Interactie score",
@@ -254,9 +254,9 @@
   "callDistByWeekDay": "Oproepverdeling per weekdag (%)",
   "addToTrackList": "Voeg tot {maxItems} contacten toe aan je volglijst voor eenvoudig bijhouden.",
   "addText": "Toevoegen",
-  "numberAlreadyAddedErrorText": "Nummer al toegevoegd",
+  "numberAlreadyAddedErrorText": "Contact al toegevoegd",
   "invalidNumberErrorText": "Ongeldig telefoonnummer",
-  "emptyPhoneNumberErrorText": "Voer een telefoonnummer in",
+  "emptyPhoneNumberErrorText": "Voer een contactnaam in",
   "trackNumberErrorText": "Er is iets misgegaan bij het toevoegen van het nieuwe contact",
   "quickFilterText": "Snelfilter"
 }

--- a/lib/l10n/app_pl.arb
+++ b/lib/l10n/app_pl.arb
@@ -240,9 +240,9 @@
   "disableLogsSharingText": "Ukryj przycisk udostępniania",
   "disableLogsSharingSubText": "Ukryj przycisk udostępniania w historii połączeń",
   "trackListLabelText": "Lista śledzenia",
-  "tracklistPlaceholderText": "Zarządzaj swoją listą śledzenia efektywnie. Stuknij + (w prawym górnym rogu), aby dodać numer, przesuń w lewo element listy i stuknij Usuń, aby przestać śledzić.",
+  "tracklistPlaceholderText": "Zarządzaj śledzonymi kontaktami efektywnie. Stuknij + (w prawym górnym rogu), aby dodać kontakt, przesuń w lewo element listy i stuknij Usuń, aby przestać śledzić.",
   "removeAllText": "usuń wszystko",
-  "trackContactLabelText": "Numer telefonu",
+  "trackContactLabelText": "Nazwa kontaktu",
   "trackContactText": "Śledź kontakt",
   "removeText": "Usuń",
   "iteractionScoreText": "Wskaźnik interakcji",
@@ -254,9 +254,9 @@
   "callDistByWeekDay": "Rozkład połączeń według dnia tygodnia (%)",
   "addToTrackList": "Dodaj do {maxItems} kontaktów do swojej listy śledzenia, aby łatwo śledzić.",
   "addText": "Dodaj",
-  "numberAlreadyAddedErrorText": "Numer już dodany",
+  "numberAlreadyAddedErrorText": "Kontakt już dodany",
   "invalidNumberErrorText": "Nieprawidłowy numer telefonu",
-  "emptyPhoneNumberErrorText": "Wprowadź numer telefonu",
+  "emptyPhoneNumberErrorText": "Wprowadź nazwę kontaktu",
   "trackNumberErrorText": "Wystąpił błąd podczas dodawania nowego kontaktu do śledzenia",
   "quickFilterText": "Szybki filtr"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -240,9 +240,9 @@
   "disableLogsSharingText": "Ocultar botão de compartilhamento",
   "disableLogsSharingSubText": "Ocultar o botão de compartilhamento nos registros de chamadas",
   "trackListLabelText": "Lista de acompanhamento",
-  "tracklistPlaceholderText": "Gerencie sua lista de acompanhamento de forma eficiente. Toque em + (canto superior direito) para adicionar um número, deslize um item da lista para a esquerda e toque em Remover para parar de acompanhar.",
+  "tracklistPlaceholderText": "Gerencie seus contatos rastreados de forma eficiente. Toque em + (canto superior direito) para adicionar um contato, deslize um item da lista para a esquerda e toque em Remover para parar de acompanhar.",
   "removeAllText": "remover tudo",
-  "trackContactLabelText": "Número de telefone",
+  "trackContactLabelText": "Nome do contato",
   "trackContactText": "Rastrear um contato",
   "removeText": "Remover",
   "iteractionScoreText": "Pontuação de interação",
@@ -254,9 +254,9 @@
   "callDistByWeekDay": "Distribuição de chamadas por dia da semana (%)",
   "addToTrackList": "Adicione até {maxItems} contatos à sua lista de acompanhamento para facilitar o rastreamento.",
   "addText": "Adicionar",
-  "numberAlreadyAddedErrorText": "Número já adicionado",
+  "numberAlreadyAddedErrorText": "Contato já adicionado",
   "invalidNumberErrorText": "Número de telefone inválido",
-  "emptyPhoneNumberErrorText": "Digite um número de telefone",
+  "emptyPhoneNumberErrorText": "Digite um nome de contato",
   "trackNumberErrorText": "Ocorreu um erro ao adicionar um novo contato à lista de acompanhamento",
   "quickFilterText": "Filtro rápido"
 }

--- a/lib/l10n/app_ro.arb
+++ b/lib/l10n/app_ro.arb
@@ -240,9 +240,9 @@
   "disableLogsSharingText": "Ascunde butonul de partajare",
   "disableLogsSharingSubText": "Ascunde butonul de partajare din jurnalul de apeluri",
   "trackListLabelText": "Lista de urmărire",
-  "tracklistPlaceholderText": "Gestionează-ți lista de urmărire eficient. Apasă + (în dreapta sus) pentru a adăuga un număr, glisează spre stânga pe un element din listă și apasă Elimină pentru a opri urmărirea.",
+  "tracklistPlaceholderText": "Gestionează-ți contactele urmărite eficient. Apasă + (în dreapta sus) pentru a adăuga un contact, glisează spre stânga pe un element din listă și apasă Elimină pentru a opri urmărirea.",
   "removeAllText": "elimină tot",
-  "trackContactLabelText": "Număr de telefon",
+  "trackContactLabelText": "Numele contactului",
   "trackContactText": "Urmărește un contact",
   "removeText": "Elimină",
   "iteractionScoreText": "Scor de interacțiune",
@@ -254,9 +254,9 @@
   "callDistByWeekDay": "Distribuția apelurilor pe zilele săptămânii (%)",
   "addToTrackList": "Adaugă până la {maxItems} contacte în lista ta de urmărire pentru o urmărire ușoară.",
   "addText": "Adaugă",
-  "numberAlreadyAddedErrorText": "Numărul a fost deja adăugat",
+  "numberAlreadyAddedErrorText": "Contactul a fost deja adăugat",
   "invalidNumberErrorText": "Număr de telefon invalid",
-  "emptyPhoneNumberErrorText": "Introduceți un număr de telefon",
+  "emptyPhoneNumberErrorText": "Introduceți un nume de contact",
   "trackNumberErrorText": "A apărut o eroare la adăugarea noului contact de urmărire",
   "quickFilterText": "Filtru rapid"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -240,9 +240,9 @@
   "disableLogsSharingText": "Скрыть кнопку «Поделиться»",
   "disableLogsSharingSubText": "Скрыть кнопку «Поделиться» в журнале звонков",
   "trackListLabelText": "Список отслеживания",
-  "tracklistPlaceholderText": "Эффективно управляйте своим списком отслеживания. Нажмите + (в правом верхнем углу), чтобы добавить номер, проведите влево по элементу списка и нажмите Удалить, чтобы перестать отслеживать.",
+  "tracklistPlaceholderText": "Эффективно управляйте отслеживаемыми контактами. Нажмите + (в правом верхнем углу), чтобы добавить контакт, проведите влево по элементу списка и нажмите Удалить, чтобы перестать отслеживать.",
   "removeAllText": "удалить всё",
-  "trackContactLabelText": "Номер телефона",
+  "trackContactLabelText": "Имя контакта",
   "trackContactText": "Отслеживать контакт",
   "removeText": "Удалить",
   "iteractionScoreText": "Оценка взаимодействия",
@@ -254,9 +254,9 @@
   "callDistByWeekDay": "Распределение звонков по дням недели (%)",
   "addToTrackList": "Добавьте до {maxItems} контактов в ваш список отслеживания для удобного контроля.",
   "addText": "Добавить",
-  "numberAlreadyAddedErrorText": "Номер уже добавлен",
+  "numberAlreadyAddedErrorText": "Контакт уже добавлен",
   "invalidNumberErrorText": "Неверный номер телефона",
-  "emptyPhoneNumberErrorText": "Введите номер телефона",
+  "emptyPhoneNumberErrorText": "Введите имя контакта",
   "trackNumberErrorText": "Произошла ошибка при добавлении нового контакта для отслеживания",
   "quickFilterText": "Быстрый фильтр"
 }

--- a/lib/l10n/app_sv.arb
+++ b/lib/l10n/app_sv.arb
@@ -240,9 +240,9 @@
     "disableLogsSharingText": "Dölj dela-knappen",
     "disableLogsSharingSubText": "Dölj dela-knappen i samtalsloggen",
     "trackListLabelText": "Spårningslista",
-    "tracklistPlaceholderText": "Hantera din spårningslista effektivt. Tryck på + (uppe till höger) för att lägga till ett nummer, svep ett listobjekt åt vänster och tryck på Ta bort för att sluta spåra.",
+    "tracklistPlaceholderText": "Hantera dina spårade kontakter effektivt. Tryck på + (uppe till höger) för att lägga till en kontakt, svep ett listobjekt åt vänster och tryck på Ta bort för att sluta spåra.",
     "removeAllText": "ta bort alla",
-    "trackContactLabelText": "Telefonnummer",
+    "trackContactLabelText": "Kontaktnamn",
     "trackContactText": "Spåra en kontakt",
     "removeText": "Ta bort",
     "iteractionScoreText": "Interaktionspoäng",
@@ -254,9 +254,9 @@
     "callDistByWeekDay": "Samtalsfördelning per veckodag (%)",
     "addToTrackList": "Lägg till upp till {maxItems} kontakter i din spårningslista för enkel uppföljning.",
     "addText": "Lägg till",
-    "numberAlreadyAddedErrorText": "Nummer redan tillagt",
+    "numberAlreadyAddedErrorText": "Kontakt redan tillagd",
     "invalidNumberErrorText": "Ogiltigt telefonnummer",
-    "emptyPhoneNumberErrorText": "Ange ett telefonnummer",
+    "emptyPhoneNumberErrorText": "Ange ett kontaktnamn",
     "trackNumberErrorText": "Ett fel uppstod vid tillägg av ny spårningskontakt",
     "quickFilterText": "Snabbfilter"
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -240,9 +240,9 @@
   "disableLogsSharingText": "Paylaşım butonunu gizle",
   "disableLogsSharingSubText": "Çağrı kayıtlarında paylaşım butonunu gizle",
   "trackListLabelText": "Takip Listesi",
-  "tracklistPlaceholderText": "Takip listenizi verimli bir şekilde yönetin. Numara eklemek için sağ üstteki + simgesine dokunun, bir liste öğesini sola kaydırın ve Takibi Kaldır'a dokunarak takipten çıkarın.",
+  "tracklistPlaceholderText": "Takip ettiğiniz kişileri verimli bir şekilde yönetin. Kişi eklemek için sağ üstteki + simgesine dokunun, bir liste öğesini sola kaydırın ve Takibi Kaldır'a dokunarak takipten çıkarın.",
   "removeAllText": "hepsini kaldır",
-  "trackContactLabelText": "Telefon Numarası",
+  "trackContactLabelText": "Kişi Adı",
   "trackContactText": "Bir Kişiyi Takip Et",
   "removeText": "Kaldır",
   "iteractionScoreText": "Etkileşim Skoru",
@@ -254,9 +254,9 @@
   "callDistByWeekDay": "Haftanın Günlerine Göre Arama Dağılımı (%)",
   "addToTrackList": "Kolay takip için takip listenize en fazla {maxItems} kişi ekleyin.",
   "addText": "Ekle",
-  "numberAlreadyAddedErrorText": "Numara zaten eklendi",
+  "numberAlreadyAddedErrorText": "Kişi zaten eklendi",
   "invalidNumberErrorText": "Geçersiz telefon numarası",
-  "emptyPhoneNumberErrorText": "Lütfen bir telefon numarası girin",
+  "emptyPhoneNumberErrorText": "Lütfen bir kişi adı girin",
   "trackNumberErrorText": "Yeni takip kişisi eklenirken bir hata oluştu",
   "quickFilterText": "Hızlı filtre"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -240,9 +240,9 @@
     "disableLogsSharingText": "隐藏分享按钮",
     "disableLogsSharingSubText": "在通话记录中隐藏分享按钮",
     "trackListLabelText": "追踪列表",
-    "tracklistPlaceholderText": "高效管理您的追踪列表。点击右上角 + 添加号码，左滑列表项并点击移除以取消追踪。",
+    "tracklistPlaceholderText": "高效管理您的追踪联系人。点击右上角 + 添加联系人，左滑列表项并点击移除以取消追踪。",
     "removeAllText": "全部移除",
-    "trackContactLabelText": "电话号码",
+    "trackContactLabelText": "联系人姓名",
     "trackContactText": "追踪联系人",
     "removeText": "移除",
     "iteractionScoreText": "互动分数",
@@ -254,9 +254,9 @@
     "callDistByWeekDay": "按星期几分布的通话比例 (%)",
     "addToTrackList": "最多添加 {maxItems} 个联系人到追踪列表，方便追踪。",
     "addText": "添加",
-    "numberAlreadyAddedErrorText": "号码已添加",
+    "numberAlreadyAddedErrorText": "联系人已添加",
     "invalidNumberErrorText": "无效的电话号码",
-    "emptyPhoneNumberErrorText": "请输入电话号码",
+    "emptyPhoneNumberErrorText": "请输入联系人姓名",
     "trackNumberErrorText": "添加新追踪联系人时出错",
     "quickFilterText": "快速筛选"
 }

--- a/lib/providers/tracklist_provider.dart
+++ b/lib/providers/tracklist_provider.dart
@@ -5,23 +5,23 @@ import 'package:logger/data/repostiory/tracklist_repository_provider.dart';
 class TrackListNotifier extends AsyncNotifier<List<TrackListItem>> {
   @override
   Future<List<TrackListItem>> build() async {
-    return ref.watch(trackListRepositoryProvider).getNumbers();
+    return ref.watch(trackListRepositoryProvider).getContacts();
   }
 
-  Future<void> registerNumber(String phoneNumber) async {
-    await ref.read(trackListRepositoryProvider).registerNumber(phoneNumber);
+  Future<void> registerContact(String contactName) async {
+    await ref.read(trackListRepositoryProvider).registerContact(contactName);
     await _updateState();
   }
 
-  Future<void> registerNumberIfNotPresent(String phoneNumber) async {
+  Future<void> registerContactIfNotPresent(String contactName) async {
     await ref
         .read(trackListRepositoryProvider)
-        .registerNumberIfNotPresent(phoneNumber);
+        .registerContactIfNotPresent(contactName);
     await _updateState();
   }
 
-  Future<void> removeNumberById(int id) async {
-    await ref.read(trackListRepositoryProvider).removeNumberById(id);
+  Future<void> removeContactById(int id) async {
+    await ref.read(trackListRepositoryProvider).removeContactById(id);
     await _updateState();
   }
 
@@ -37,7 +37,7 @@ class TrackListNotifier extends AsyncNotifier<List<TrackListItem>> {
   Future<void> _updateState() async {
     state = const AsyncLoading();
     state = await AsyncValue.guard(
-      () => ref.read(trackListRepositoryProvider).getNumbers(),
+      () => ref.read(trackListRepositoryProvider).getContacts(),
     );
   }
 }

--- a/lib/screens/tracklist/fragments/add_new_number_to_track_list_dialog.dart
+++ b/lib/screens/tracklist/fragments/add_new_number_to_track_list_dialog.dart
@@ -1,87 +1,170 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logger/data/models/tracklist_item.dart';
-import 'package:logger/utils/format_helpers.dart';
-import 'package:logger/utils/phone_formatter.dart';
+import 'package:logger/providers/call_logs_provider.dart';
 import 'package:logger/utils/constants.dart' as constants;
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
-class AddNewNumberToTrackListDialog extends ConsumerStatefulWidget {
-  final List<TrackListItem> currentNumbers;
+class AddNewContactToTrackListDialog extends ConsumerStatefulWidget {
+  final List<TrackListItem> currentContacts;
 
-  const AddNewNumberToTrackListDialog(
-      {super.key, required this.currentNumbers});
+  const AddNewContactToTrackListDialog(
+      {super.key, required this.currentContacts});
 
   @override
-  ConsumerState<AddNewNumberToTrackListDialog> createState() =>
-      AddNewNumberToTrackListDialogState();
+  ConsumerState<AddNewContactToTrackListDialog> createState() =>
+      _AddNewContactToTrackListDialogState();
 }
 
-class AddNewNumberToTrackListDialogState
-    extends ConsumerState<AddNewNumberToTrackListDialog> {
+class _AddNewContactToTrackListDialogState
+    extends ConsumerState<AddNewContactToTrackListDialog> {
   String? _errorText;
-  final _controller = TextEditingController();
-  final formKey = GlobalKey<FormState>();
+  String _currentText = '';
 
-  @override
-  void initState() {
-    super.initState();
-    _controller.addListener(() {
-      setState(() {});
-    });
+  List<String> _getAvailableContactNames() {
+    final callLogs = ref.read(callLogsNotifierProvider).value ?? [];
+    final trackedNames =
+        widget.currentContacts.map((e) => e.contactName).toSet();
+
+    final names = <String>{};
+    for (final entry in callLogs) {
+      final name = entry.name;
+      if (name != null && name.isNotEmpty && !trackedNames.contains(name)) {
+        names.add(name);
+      }
+    }
+
+    final sorted = names.toList()..sort();
+    return sorted;
   }
 
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
+  void _submit(String value) {
+    final trimmed = value.trim();
+
+    if (trimmed.isEmpty) {
+      setState(() {
+        _errorText = AppLocalizations.of(context).emptyPhoneNumberErrorText;
+      });
+      return;
+    }
+
+    if (widget.currentContacts
+        .map((e) => e.contactName)
+        .contains(trimmed)) {
+      setState(() {
+        _errorText = AppLocalizations.of(context).numberAlreadyAddedErrorText;
+      });
+      return;
+    }
+
+    Navigator.of(context).pop(trimmed);
   }
 
   @override
   Widget build(BuildContext context) {
+    final availableContacts = _getAvailableContactNames();
+
     return AlertDialog(
       title: Text(AppLocalizations.of(context).trackContactText),
-      content: SingleChildScrollView(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(
-              AppLocalizations.of(context).addToTrackList(
-                constants.maxAllowedTrackListItems,
-              ),
-            ),
-            SizedBox(height: 16),
-            Form(
-              key: formKey,
-              child: TextFormField(
-                autofocus: true,
-                controller: _controller,
-                keyboardType: TextInputType.phone,
-                inputFormatters: [NoSpaceFormatter()],
-                decoration: InputDecoration(
-                  suffixIcon: _controller.text.isNotEmpty
-                      ? IconButton(
-                          icon: const Icon(Icons.clear),
-                          onPressed: () {
-                            _controller.clear();
-                          },
-                        )
-                      : null,
-                  labelText: AppLocalizations.of(context).trackContactLabelText,
-                  hintText: AppLocalizations.of(context).hintMobileNumberText,
-                  border: OutlineInputBorder(),
-                  errorText: _errorText,
+      content: SizedBox(
+        width: double.maxFinite,
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                AppLocalizations.of(context).addToTrackList(
+                  constants.maxAllowedTrackListItems,
                 ),
-                onChanged: (value) {
-                  if (_errorText != null && value.trim().isEmpty) {
-                    setState(() {
-                      _errorText = null;
-                    });
+              ),
+              SizedBox(height: 16),
+              Autocomplete<String>(
+                optionsBuilder: (TextEditingValue textEditingValue) {
+                  if (textEditingValue.text.isEmpty) {
+                    return availableContacts;
                   }
+                  return availableContacts.where((name) => name
+                      .toLowerCase()
+                      .contains(textEditingValue.text.toLowerCase()));
+                },
+                onSelected: (String selection) {
+                  _currentText = selection;
+                },
+                fieldViewBuilder: (context, textController, focusNode,
+                    onFieldSubmitted) {
+                  textController.addListener(() {
+                    _currentText = textController.text;
+                    if (_errorText != null &&
+                        textController.text.trim().isEmpty) {
+                      setState(() {
+                        _errorText = null;
+                      });
+                    }
+                  });
+
+                  return TextField(
+                    controller: textController,
+                    focusNode: focusNode,
+                    autofocus: true,
+                    decoration: InputDecoration(
+                      suffixIcon: textController.text.isNotEmpty
+                          ? IconButton(
+                              icon: const Icon(Icons.clear),
+                              onPressed: () {
+                                textController.clear();
+                                _currentText = '';
+                              },
+                            )
+                          : null,
+                      labelText:
+                          AppLocalizations.of(context).trackContactLabelText,
+                      hintText: AppLocalizations.of(context)
+                          .trackContactLabelText,
+                      border: OutlineInputBorder(),
+                      errorText: _errorText,
+                    ),
+                    onSubmitted: (_) => _submit(textController.text),
+                  );
+                },
+                optionsViewBuilder: (context, onSelected, options) {
+                  return Align(
+                    alignment: Alignment.topLeft,
+                    child: Material(
+                      elevation: 4.0,
+                      borderRadius: BorderRadius.circular(8.0),
+                      child: ConstrainedBox(
+                        constraints: BoxConstraints(
+                          maxHeight: 200,
+                          maxWidth:
+                              MediaQuery.of(context).size.width * 0.65,
+                        ),
+                        child: ListView.builder(
+                          padding: EdgeInsets.zero,
+                          shrinkWrap: true,
+                          itemCount: options.length,
+                          itemBuilder: (context, index) {
+                            final option = options.elementAt(index);
+                            return ListTile(
+                              dense: true,
+                              leading: CircleAvatar(
+                                radius: 16,
+                                child: Text(
+                                  option[0],
+                                  style: const TextStyle(fontSize: 14),
+                                ),
+                              ),
+                              title: Text(option),
+                              onTap: () => onSelected(option),
+                            );
+                          },
+                        ),
+                      ),
+                    ),
+                  );
                 },
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
       actions: [
@@ -90,39 +173,7 @@ class AddNewNumberToTrackListDialogState
           child: Text(AppLocalizations.of(context).cancelText),
         ),
         OutlinedButton(
-          onPressed: () {
-            String value = _controller.text.trim();
-            value = PhoneFormatter.parsePhoneNumber(value);
-
-            if (value.isEmpty) {
-              setState(() {
-                _errorText =
-                    AppLocalizations.of(context).emptyPhoneNumberErrorText;
-              });
-              return;
-            }
-
-            final phoneRegEx = RegExp(r'^\+?\d{7,15}$');
-            if (!phoneRegEx.hasMatch(value)) {
-              setState(() {
-                _errorText =
-                    AppLocalizations.of(context).invalidNumberErrorText;
-              });
-              return;
-            }
-
-            if (widget.currentNumbers
-                .map((e) => e.phoneNumber)
-                .contains(value.trim())) {
-              setState(() {
-                _errorText =
-                    AppLocalizations.of(context).numberAlreadyAddedErrorText;
-              });
-              return;
-            }
-
-            Navigator.of(context).pop(value);
-          },
+          onPressed: () => _submit(_currentText),
           child: Text(
             AppLocalizations.of(context).addText,
           ),

--- a/lib/screens/tracklist/fragments/tracklist_item_ui.dart
+++ b/lib/screens/tracklist/fragments/tracklist_item_ui.dart
@@ -27,20 +27,22 @@ class TracklistItemUi extends ConsumerStatefulWidget {
 }
 
 class _TracklistItemUiState extends ConsumerState<TracklistItemUi> {
-  Future<TrackingMetrics> getMetrics(String phoneNumber) async {
+  Future<TrackingMetrics> getMetrics(String contactName) async {
     var entries = ref.watch(callLogsNotifierProvider).value ?? [];
-    var mappedEntries = entries.where(
-        (e) => PhoneFormatter.parsePhoneNumber(e.number ?? "") == phoneNumber);
+    var mappedEntries =
+        entries.where((e) => e.name == contactName);
     return parseTrackingMetrics(mappedEntries);
   }
 
   @override
   Widget build(BuildContext context) {
     return FutureBuilder(
-      future: getMetrics(widget.item.phoneNumber),
+      future: getMetrics(widget.item.contactName),
       builder: (context, snapshot) {
         if (snapshot.hasData) {
           if (snapshot.data == null) return const SizedBox();
+
+          final phoneNumber = snapshot.data!.lastCallEntry?.number;
 
           return Material(
             clipBehavior: Clip.hardEdge,
@@ -69,11 +71,12 @@ class _TracklistItemUiState extends ConsumerState<TracklistItemUi> {
                         child: SlidableAction(
                           autoClose: true,
                           flex: 1,
-                          onPressed: (context) async {
-                            var uri =
-                                Uri.parse("tel:${widget.item.phoneNumber}");
-                            await launchUrl(uri);
-                          },
+                          onPressed: phoneNumber != null
+                              ? (context) async {
+                                  var uri = Uri.parse("tel:$phoneNumber");
+                                  await launchUrl(uri);
+                                }
+                              : null,
                           backgroundColor:
                               Theme.of(context).brightness == Brightness.dark
                                   ? const Color.fromARGB(255, 60, 60, 60)
@@ -93,7 +96,7 @@ class _TracklistItemUiState extends ConsumerState<TracklistItemUi> {
                       onPressed: (context) async {
                         await ref
                             .read(trackListProvider.notifier)
-                            .removeNumberById(widget.item.id);
+                            .removeContactById(widget.item.id);
                       },
                       backgroundColor: Colors.redAccent,
                       icon: Icons.delete,
@@ -103,6 +106,8 @@ class _TracklistItemUiState extends ConsumerState<TracklistItemUi> {
                 ),
                 child: ListTile(
                   onLongPress: () async {
+                    if (snapshot.data!.lastCallEntry == null) return;
+
                     bool isUnknown = CallDisplayHelper.isUnknownContact(
                       snapshot.data!.lastCallEntry!,
                     );
@@ -115,18 +120,20 @@ class _TracklistItemUiState extends ConsumerState<TracklistItemUi> {
                               context, snapshot.data!.lastCallEntry!.number);
                     }
                   },
-                  trailing: IconButton(
-                    onPressed: () async {
-                      ref.read(screenIndexProvider.notifier).setIndex(0);
-                      await ref
-                          .read(logsFilterProvider.notifier)
-                          .filterByPhoneNumber(
-                            widget.item.phoneNumber,
-                          );
-                    },
-                    icon: Icon(Icons.electric_bolt),
-                    tooltip: AppLocalizations.of(context).quickFilterText,
-                  ),
+                  trailing: phoneNumber != null
+                      ? IconButton(
+                          onPressed: () async {
+                            ref.read(screenIndexProvider.notifier).setIndex(0);
+                            await ref
+                                .read(logsFilterProvider.notifier)
+                                .filterByPhoneNumber(
+                                  PhoneFormatter.parsePhoneNumber(phoneNumber),
+                                );
+                          },
+                          icon: Icon(Icons.electric_bolt),
+                          tooltip: AppLocalizations.of(context).quickFilterText,
+                        )
+                      : null,
                   onTap: () {
                     Navigator.push(context, MaterialPageRoute(
                       builder: (context) {
@@ -136,40 +143,42 @@ class _TracklistItemUiState extends ConsumerState<TracklistItemUi> {
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [
                                 Text(
-                                  snapshot.data!.lastCallEntry?.name ??
-                                      AppLocalizations.of(context).unknownText,
+                                  widget.item.contactName,
                                   style: const TextStyle(
                                     fontSize: 20.0,
                                   ),
                                 ),
-                                Text(
-                                  widget.item.phoneNumber,
-                                  style: const TextStyle(
-                                    color: Colors.grey,
-                                    fontSize: 12,
-                                  ),
-                                )
+                                if (phoneNumber != null)
+                                  Text(
+                                    phoneNumber,
+                                    style: const TextStyle(
+                                      color: Colors.grey,
+                                      fontSize: 12,
+                                    ),
+                                  )
                               ],
                             ),
                             actions: [
-                              IconButton(
-                                onPressed: () async {
-                                  var uri = Uri.parse(
-                                      "tel:${widget.item.phoneNumber}");
-                                  await launchUrl(uri);
-                                },
-                                icon: Icon(Icons.call),
-                                tooltip: AppLocalizations.of(context).callText,
-                              ),
-                              IconButton(
-                                onPressed: () async {
-                                  var uri = Uri.parse(
-                                      "sms:${widget.item.phoneNumber}");
-                                  await launchUrl(uri);
-                                },
-                                icon: Icon(Icons.sms),
-                                tooltip: AppLocalizations.of(context).smsText,
-                              ),
+                              if (phoneNumber != null) ...[
+                                IconButton(
+                                  onPressed: () async {
+                                    var uri = Uri.parse("tel:$phoneNumber");
+                                    await launchUrl(uri);
+                                  },
+                                  icon: Icon(Icons.call),
+                                  tooltip:
+                                      AppLocalizations.of(context).callText,
+                                ),
+                                IconButton(
+                                  onPressed: () async {
+                                    var uri = Uri.parse("sms:$phoneNumber");
+                                    await launchUrl(uri);
+                                  },
+                                  icon: Icon(Icons.sms),
+                                  tooltip:
+                                      AppLocalizations.of(context).smsText,
+                                ),
+                              ],
                               SizedBox(
                                 width: 10.0,
                               ),
@@ -200,8 +209,7 @@ class _TracklistItemUiState extends ConsumerState<TracklistItemUi> {
                                               AppLocalizations.of(context)
                                                   .iteractionScoreText,
                                               style: TextStyle(
-                                                fontSize:
-                                                    16, // adjust for dark background
+                                                fontSize: 16,
                                               ),
                                             ),
                                             Text(
@@ -360,24 +368,27 @@ class _TracklistItemUiState extends ConsumerState<TracklistItemUi> {
                             },
                           )
                         : Text(
-                            (snapshot.data!.lastCallEntry?.name ?? "?")[0],
+                            widget.item.contactName.isNotEmpty
+                                ? widget.item.contactName[0]
+                                : "?",
                             style: const TextStyle(fontSize: 25),
                           ),
                   ),
                   title: Text(
-                    snapshot.data!.lastCallEntry?.name ??
-                        AppLocalizations.of(context).unknownText,
+                    widget.item.contactName,
                     style: const TextStyle(
                       fontSize: 20.0,
                     ),
                   ),
-                  subtitle: Text(
-                    widget.item.phoneNumber,
-                    style: const TextStyle(
-                      color: Colors.grey,
-                      fontSize: 16,
-                    ),
-                  ),
+                  subtitle: phoneNumber != null
+                      ? Text(
+                          phoneNumber,
+                          style: const TextStyle(
+                            color: Colors.grey,
+                            fontSize: 16,
+                          ),
+                        )
+                      : null,
                 ),
               ),
             ),

--- a/lib/screens/tracklist/fragments/tracklist_item_ui_builder.dart
+++ b/lib/screens/tracklist/fragments/tracklist_item_ui_builder.dart
@@ -6,32 +6,32 @@ class TracklistItemUiBuilder {
   TracklistItemUiBuilder._();
   factory TracklistItemUiBuilder() => _instance;
 
-  final List<TrackListItem> _currentNumbers = [];
+  final List<TrackListItem> _currentContacts = [];
   final List<TracklistItemUi> _currentTrackListUi = [];
 
   static bool areListsEqual(List<TrackListItem> a, List<TrackListItem> b) {
-    final aSet = a.map((e) => e.phoneNumber).toSet();
-    final bSet = b.map((e) => e.phoneNumber).toSet();
+    final aSet = a.map((e) => e.contactName).toSet();
+    final bSet = b.map((e) => e.contactName).toSet();
     return aSet.length == bSet.length && aSet.containsAll(bSet);
   }
 
   static List<TrackListItem> getNewItems(
       List<TrackListItem> oldList, List<TrackListItem> newList) {
-    final oldSet = oldList.map((e) => e.phoneNumber).toSet();
-    return newList.where((e) => !oldSet.contains(e.phoneNumber)).toList();
+    final oldSet = oldList.map((e) => e.contactName).toSet();
+    return newList.where((e) => !oldSet.contains(e.contactName)).toList();
   }
 
-  List<TracklistItemUi> build(List<TrackListItem> newNumbers) {
-    if (areListsEqual(_currentNumbers, newNumbers)) {
+  List<TracklistItemUi> build(List<TrackListItem> newContacts) {
+    if (areListsEqual(_currentContacts, newContacts)) {
       return _currentTrackListUi;
     }
 
-    final newNumberSet = newNumbers.map((e) => e.phoneNumber).toSet();
+    final newContactSet = newContacts.map((e) => e.contactName).toSet();
     _currentTrackListUi.removeWhere(
-      (ui) => !newNumberSet.contains(ui.item.phoneNumber),
+      (ui) => !newContactSet.contains(ui.item.contactName),
     );
 
-    final newItems = getNewItems(_currentNumbers, newNumbers);
+    final newItems = getNewItems(_currentContacts, newContacts);
     _currentTrackListUi.addAll(
       newItems.map(
         (item) => TracklistItemUi(
@@ -40,15 +40,15 @@ class TracklistItemUiBuilder {
       ),
     );
 
-    _currentNumbers
+    _currentContacts
       ..clear()
-      ..addAll(newNumbers);
+      ..addAll(newContacts);
 
     return _currentTrackListUi;
   }
 
   void clearCache() {
-    _currentNumbers.clear();
+    _currentContacts.clear();
     _currentTrackListUi.clear();
   }
 }


### PR DESCRIPTION
Hi, this is an attempt to make the app track contacts by name instead of tracking them by phone number.

This should solve the current behavior where, if a contact has different phone numbers, the app tracks them as different contacts, each with their own separate statistics: https://github.com/Sanmeet007/logger/issues/37#issuecomment-3360573484.

Disclaimer: the code modifications were made by an LLM, but I checked it in my fork and it seems to work.

I waive any claim to attribution: there is no need to add me to the list of authors.