### PR TITLE
fix: use current entry's number when grouping call logs

### DIFF
--- a/lib/utils/grouper.dart
+++ b/lib/utils/grouper.dart
@@ -51,7 +51,7 @@ class LogsGrouper {
       var curr = entries[i];
 
       final prevNumber = PhoneFormatter.parsePhoneNumber(prev.number ?? "");
-      final currNumber = PhoneFormatter.parsePhoneNumber(prev.number ?? "");
+      final currNumber = PhoneFormatter.parsePhoneNumber(curr.number ?? "");
 
       String prevKey =
           (prev.name ?? '') + (prevNumber) + (prev.callType?.toString() ?? '');
@@ -82,7 +82,7 @@ class LogsGrouper {
       var curr = entries[i];
 
       final prevNumber = PhoneFormatter.parsePhoneNumber(prev.number ?? "");
-      final currNumber = PhoneFormatter.parsePhoneNumber(prev.number ?? "");
+      final currNumber = PhoneFormatter.parsePhoneNumber(curr.number ?? "");
 
       String prevKey = (prev.name ?? '') + (prevNumber);
       String currKey = (curr.name ?? '') + (currNumber);


### PR DESCRIPTION
## Problem

Both grouping helpers in `LogsGrouper` (`groupByContactAndType` and `groupByContactOnlyConsecutive`) build the *current* entry's grouping key from `prev.number` instead of `curr.number`:

```dart
final prevNumber = PhoneFormatter.parsePhoneNumber(prev.number ?? "");
final currNumber = PhoneFormatter.parsePhoneNumber(prev.number ?? ""); // bug: prev, not curr
```

So the number component of the key is always taken from the previous entry. Two consecutive calls of the same type but from **different numbers** collapse into a single group. This is most visible for unknown numbers, where the number is the only field distinguishing one caller from another.

## Fix

Parse `curr.number` for `currNumber` in both helpers.

## Testing

Verified on-device (GrapheneOS): consecutive calls from different unknown numbers are now grouped separately as expected.