### PR TITLE
feat: add 'unknown contacts only' filter

### DIFF
--- a/lib/core/log_filters.dart
+++ b/lib/core/log_filters.dart
@@ -49,6 +49,7 @@ class _LogFiltersState extends ConsumerState<LogFilters> {
   late int currentPresetId;
   late bool isNumberSearchEnabled;
   late bool isDurationFilteringOn;
+  late bool showUnknownContactsOnly;
   late DateRange dateRangeOption;
   late List<CallType> selectedCallTypes;
   late String selectedPhoneAccountId;
@@ -91,6 +92,7 @@ class _LogFiltersState extends ConsumerState<LogFilters> {
     selectedCallTypes = widget.currentFilter.selectedCallTypes;
     isDurationFilteringOn = widget.currentFilter.usesDurationFiltering;
     selectedPhoneAccountId = widget.currentFilter.phoneAccountId;
+    showUnknownContactsOnly = widget.currentFilter.showUnknownContactsOnly;
   }
 
   @override
@@ -141,6 +143,13 @@ class _LogFiltersState extends ConsumerState<LogFilters> {
     checkFiltersState();
   }
 
+  void setShowUnknownContactsOnly(bool v) {
+    setState(() {
+      showUnknownContactsOnly = v;
+    });
+    checkFiltersState();
+  }
+
   void applyFilters() async {
     final ref = widget.parentRef;
     Navigator.pop(context, true);
@@ -175,6 +184,7 @@ class _LogFiltersState extends ConsumerState<LogFilters> {
                       ),
                 usesDurationFiltering: isDurationFilteringOn,
                 phoneAccountId: selectedPhoneAccountId,
+                showUnknownContactsOnly: showUnknownContactsOnly,
               ),
               currentPresetId,
             );
@@ -215,6 +225,7 @@ class _LogFiltersState extends ConsumerState<LogFilters> {
                 seconds: int.tryParse(_maxDurationInputController.text) ?? 0,
               ),
         phoneAccountId: selectedPhoneAccountId,
+        showUnknownContactsOnly: showUnknownContactsOnly,
       ),
       widget.currentFilter,
     );
@@ -309,6 +320,8 @@ class _LogFiltersState extends ConsumerState<LogFilters> {
         isDurationFilteringOn =
             Filter.defaultFilterConfig.usesDurationFiltering;
         selectedPhoneAccountId = Filter.defaultFilterConfig.phoneAccountId;
+        showUnknownContactsOnly =
+            Filter.defaultFilterConfig.showUnknownContactsOnly;
       });
     } else {
       setState(() {
@@ -494,6 +507,28 @@ class _LogFiltersState extends ConsumerState<LogFilters> {
                 if (widget.canFilterUsingPhoneAccountId &&
                     currentPresetId == -1)
                   const SizedBox(height: 10.0),
+                if (currentPresetId == -1)
+                  Container(
+                    clipBehavior: Clip.hardEdge,
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).colorScheme.surface,
+                      borderRadius: BorderRadius.circular(20.0),
+                    ),
+                    child: Material(
+                      child: SwitchListTile(
+                        contentPadding: const EdgeInsets.symmetric(
+                            horizontal: 15.0, vertical: 5.0),
+                        title: SizedText(
+                          AppLocalizations.of(context)
+                              .showUnknownContactsOnlyText,
+                          size: 18.0,
+                        ),
+                        value: showUnknownContactsOnly,
+                        onChanged: setShowUnknownContactsOnly,
+                      ),
+                    ),
+                  ),
+                if (currentPresetId == -1) const SizedBox(height: 10.0),
                 if (widget.canFilterUsingDuration && currentPresetId == -1)
                   Container(
                     clipBehavior: Clip.hardEdge,

--- a/lib/data/datasource/datasource.dart
+++ b/lib/data/datasource/datasource.dart
@@ -21,7 +21,7 @@ class Datasource {
   Future<Database> _initDb() async {
     return await openDatabase(
       dbName,
-      version: 2,
+      version: 3,
       onCreate: _onCreate,
       onUpgrade: _onUpgrade,
     );
@@ -36,6 +36,7 @@ class Datasource {
         uses_specific_phone_number INTEGER DEFAULT 0,
         specific_phone_number TEXT,
         uses_filter_by_call_duration INTEGER DEFAULT 0,
+        show_unknown_contacts_only INTEGER DEFAULT 0,
         call_min_duration INTEGER,
         call_max_duration INTEGER,
         selected_call_types TEXT,
@@ -64,6 +65,12 @@ class Datasource {
         creation_timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
       )
     ''');
+    }
+    if (oldVersion < 3) {
+      await db.execute(
+        'ALTER TABLE ${FilterPresetDatasource.tableName} '
+        'ADD COLUMN show_unknown_contacts_only INTEGER DEFAULT 0',
+      );
     }
   }
 

--- a/lib/data/models/filter_preset.dart
+++ b/lib/data/models/filter_preset.dart
@@ -27,6 +27,7 @@ class FilterPreset {
       "uses_specific_phone_number": filterDetails.usesSpecificPhoneNumber,
       "specific_phone_number": filterDetails.phoneToMatch,
       "uses_filter_by_call_duration": filterDetails.usesDurationFiltering,
+      "show_unknown_contacts_only": filterDetails.showUnknownContactsOnly,
       "call_min_duration": filterDetails.minDuration.inSeconds,
       "call_max_duration": filterDetails.maxDuration?.inSeconds,
       "selected_call_types":
@@ -46,6 +47,8 @@ class FilterPreset {
         usesSpecificPhoneNumber: (map["uses_specific_phone_number"] ?? 0) == 1,
         phoneToMatch: map["specific_phone_number"],
         usesDurationFiltering: (map["uses_filter_by_call_duration"] ?? 0) == 1,
+        showUnknownContactsOnly:
+            (map["show_unknown_contacts_only"] ?? 0) == 1,
         minDuration: Duration(seconds: map["call_min_duration"] ?? 0),
         maxDuration: map["call_max_duration"] != null
             ? Duration(seconds: map["call_max_duration"])

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -474,6 +474,9 @@
   "@filterByDurationText": {
     "description": "Text for filtering by call duration"
   },
+  "@showUnknownContactsOnlyText": {
+    "description": "Text for showing only calls from numbers not saved in contacts"
+  },
   "@filterByCallTypeText": {
     "description": "Text for filtering by call type"
   },
@@ -714,6 +717,7 @@
   "searchByNumberText": "Specific Phone Number",
   "phoneAccountIdFilterText": "Phone Account ID",
   "filterByDurationText": "Filter by Call Duration",
+  "showUnknownContactsOnlyText": "Unknown Contacts Only",
   "filterByCallTypeText": "Call Type",
   "answeredExternallyText": "Answered Externally",
   "voiceMailText": "Voice Mail",

--- a/lib/screens/settings/preset_editor.dart
+++ b/lib/screens/settings/preset_editor.dart
@@ -37,6 +37,7 @@ class _PresetEditorState extends ConsumerState<PresetEditor> {
   bool canSaveFilters = false;
   late bool isNumberSearchEnabled;
   late bool isDurationFilteringOn;
+  late bool showUnknownContactsOnly;
   late String selectedPhoneAccountId;
   late DateRange dateRangeOption;
   late List<CallType> selectedCallTypes;
@@ -65,6 +66,13 @@ class _PresetEditorState extends ConsumerState<PresetEditor> {
   void setFilterByDurationState(bool v) {
     setState(() {
       isDurationFilteringOn = v;
+    });
+    checkFiltersState();
+  }
+
+  void setShowUnknownContactsOnly(bool v) {
+    setState(() {
+      showUnknownContactsOnly = v;
     });
     checkFiltersState();
   }
@@ -172,6 +180,7 @@ class _PresetEditorState extends ConsumerState<PresetEditor> {
                 seconds: int.tryParse(_maxDurationInputController.text) ?? 0,
               ),
         phoneAccountId: selectedPhoneAccountId,
+        showUnknownContactsOnly: showUnknownContactsOnly,
       ),
       widget.preset.filterDetails,
     );
@@ -201,6 +210,7 @@ class _PresetEditorState extends ConsumerState<PresetEditor> {
                 seconds: int.tryParse(_maxDurationInputController.text) ?? 0,
               ),
         phoneAccountId: selectedPhoneAccountId,
+        showUnknownContactsOnly: showUnknownContactsOnly,
       );
 
       if (presetId == -1) {
@@ -265,6 +275,8 @@ class _PresetEditorState extends ConsumerState<PresetEditor> {
 
     isNumberSearchEnabled = widget.preset.filterDetails.usesSpecificPhoneNumber;
     isDurationFilteringOn = widget.preset.filterDetails.usesDurationFiltering;
+    showUnknownContactsOnly =
+        widget.preset.filterDetails.showUnknownContactsOnly;
   }
 
   @override
@@ -375,6 +387,26 @@ class _PresetEditorState extends ConsumerState<PresetEditor> {
                         ),
                       ),
                   ],
+                ),
+              ),
+              const SizedBox(height: 10.0),
+              Container(
+                clipBehavior: Clip.hardEdge,
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.surface,
+                  borderRadius: BorderRadius.circular(20.0),
+                ),
+                child: Material(
+                  child: SwitchListTile(
+                    contentPadding: const EdgeInsets.symmetric(
+                        horizontal: 15.0, vertical: 5.0),
+                    title: SizedText(
+                      AppLocalizations.of(context).showUnknownContactsOnlyText,
+                      size: 18.0,
+                    ),
+                    value: showUnknownContactsOnly,
+                    onChanged: setShowUnknownContactsOnly,
+                  ),
                 ),
               ),
               const SizedBox(height: 10.0),

--- a/lib/utils/filters.dart
+++ b/lib/utils/filters.dart
@@ -17,6 +17,7 @@ class Filter {
   Duration? maxDuration;
   bool usesDurationFiltering;
   String phoneAccountId;
+  bool showUnknownContactsOnly;
 
   static final Filter defaultFilterConfig = Filter();
 
@@ -31,6 +32,7 @@ class Filter {
     this.maxDuration,
     this.usesDurationFiltering = false,
     this.phoneAccountId = constants.defaultPhoneAccountId,
+    this.showUnknownContactsOnly = false,
   })  : selectedCallTypes = selectedCallTypes ?? [...CallType.values],
         startDate = startDate ?? DateTime.now(),
         endDate = endDate ?? DateTime.now();
@@ -47,6 +49,7 @@ class Filter {
     bool? usesDurationFiltering,
     bool? usesPhoneAccountId,
     String? phoneAccountId,
+    bool? showUnknownContactsOnly,
   }) {
     return Filter(
       usesSpecificPhoneNumber:
@@ -61,6 +64,8 @@ class Filter {
       usesDurationFiltering:
           usesDurationFiltering ?? this.usesDurationFiltering,
       phoneAccountId: phoneAccountId ?? this.phoneAccountId,
+      showUnknownContactsOnly:
+          showUnknownContactsOnly ?? this.showUnknownContactsOnly,
     );
   }
 }
@@ -83,6 +88,7 @@ class FilterUtils {
     var maxDuration = filter.maxDuration?.inSeconds;
     var shouldUseDurationFiltering = filter.usesDurationFiltering;
     var phoneAccountId = filter.phoneAccountId;
+    var showUnknownContactsOnly = filter.showUnknownContactsOnly;
 
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day);
@@ -98,6 +104,10 @@ class FilterUtils {
         (e.number?.contains(phoneToMatch) ?? false);
 
     bool matchesCallType(CallLogEntry e) => callTypes.contains(e.callType);
+
+    // Unknown = not saved in contacts, i.e. no name attached to the entry.
+    bool matchesUnknownContact(CallLogEntry e) =>
+        !showUnknownContactsOnly || (e.name == null || e.name!.isEmpty);
 
     bool matchesDate(CallLogEntry e) {
       final entryDate = DateTime.fromMillisecondsSinceEpoch(e.timestamp ?? 1);
@@ -139,7 +149,8 @@ class FilterUtils {
         matchesCallType(e) &&
         matchesDate(e) &&
         matchesDuration(e) &&
-        matchesPhoneAccount(e));
+        matchesPhoneAccount(e) &&
+        matchesUnknownContact(e));
   }
 
   static Future<Iterable<CallLogEntry>> filterLogs(
@@ -159,6 +170,7 @@ class FilterUtils {
         filter1.dateRangeOption != filter2.dateRangeOption ||
         filter1.phoneAccountId != filter2.phoneAccountId ||
         filter1.usesDurationFiltering != filter2.usesDurationFiltering ||
+        filter1.showUnknownContactsOnly != filter2.showUnknownContactsOnly ||
         filter1.minDuration != filter2.minDuration ||
         (filter1.maxDuration ?? Duration.zero) !=
             (filter2.maxDuration ?? Duration.zero)) {


### PR DESCRIPTION
## What

Adds a filter toggle that restricts the call log to entries from numbers **not saved in contacts** — the ones the app shows as "Unknown". Useful for reviewing calls from unknown/unsaved numbers (e.g. on GrapheneOS where contact access is often scoped).

An entry is considered unknown when it has no contact name (`name == null || name.isEmpty`), matching the existing `CallDisplayHelper.isUnknownContact` definition.

## Changes

- **`Filter`**: new `showUnknownContactsOnly` flag; applied in `_getFilteredLogs` and accounted for in `compareFilterMasks`.
- **Filter sheet** (`log_filters`) and **preset editor**: a `SwitchListTile` toggle.
- **Presets**: the flag is persisted. DB schema bumped `2 → 3` with an `onUpgrade` migration adding a `show_unknown_contacts_only` column (defaults to 0, so existing presets are unaffected).
- **l10n**: new `showUnknownContactsOnlyText` key in the `en` template; other locales fall back to English until translated.

## Testing

Verified on-device (GrapheneOS): toggling it on shows only calls from numbers not in contacts, both as an ad-hoc filter and saved into a preset (survives app restart via the DB migration).